### PR TITLE
Add note about disabling Language Sass package to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 This package is converted from the Sublime Text 2/3 [Syntax-highlighting-for-Sass](https://github.com/P233/Syntax-highlighting-for-Sass) package. For some reasons, completions haven't been converted. I'll make an update later.
 
-Please feel free to [fill an issue](https://github.com/P233/Atom-Syntax-highlighting-for-Sass/issues/new) if you get any problem with this package or have any suggestions.
+**Note**: In order to make the syntax grammars defined by this package your defaults for `.sass` and `.scss` files, you must first disable the built-in [Language Sass package](https://github.com/atom/language-sass).
+
+Please feel free to [file an issue](https://github.com/P233/Atom-Syntax-highlighting-for-Sass/issues/new) if you have any problems with this package or have any suggestions.

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -409,4 +409,4 @@
   'variable':
     'match': '\\$[a-zA-Z0-9_-]+'
     'name': 'variable.other.value'
-'scopeName': 'source.scss'
+'scopeName': 'source.css.scss'


### PR DESCRIPTION
Fix #2. I also noticed that the Sass grammar `scopeName`, `source.sass`, exactly matches the corresponding grammar in the Language Sass package, while the SCSS grammar `scopName`, `source.scss`, does not (Language Sass uses `source.css.scss`), so I updated that, too.
